### PR TITLE
Add sessions to requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
-* @zaanposni @Monkmitrad @ArPiiX
+* @zaanposni
 
 # PYTHON
-*.py @zaanposni @Monkmitrad @ArPiiX
+*.py @zaanposni
 /requirements.txt @zaanposni
 
 # UNITTESTS

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,7 +22,7 @@ copyright = '2019-2022, zaanposni'
 author = 'zaanposni'
 
 # The full version, including alpha/beta/rc tags
-release = '1.1.4'
+release = '1.2.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("readme.md", "r") as fh:
 setup(
   name='vvspy',
   py_modules=["vvspy"],
-  version='1.1.4',
+  version='1.2.0',
   license='MIT',
   description='API Wrapper for VVS (Verkehrsverbund Stuttgart)',
   author='zaanposni',

--- a/vvspy/__init__.py
+++ b/vvspy/__init__.py
@@ -2,6 +2,7 @@ from datetime import datetime as __datetime
 from typing import List as __List
 from typing import Union as __Union
 from requests.models import Response as __Response
+from requests import Session
 
 from .obj import Arrival as __Arrival
 from .obj import Departure as __Departure
@@ -11,23 +12,40 @@ from .departures import get_departures
 from .arrivals import get_arrivals
 
 
-def departures_now(station_id: __Union[str, int], limit: int = 100, return_resp: bool = False,
-                   **kwargs) -> __Union[__List[__Departure], __Response, None]:
+def departures_now(
+    station_id: __Union[str, int],
+    limit: int = 100,
+    return_resp: bool = False,
+    session: Session = None,
+    **kwargs
+) -> __Union[__List[__Departure], __Response, None]:
     """
-        Same as `get_departures`
-        But `datetime.datetime.now()` is already used as parameter.
+    Same as `get_departures`
+    But `datetime.datetime.now()` is already used as parameter.
 
-        Returns: List[:class:`vvspy.obj.Departure`]
-        Returns none on webrequest errors or no results found.
+    Returns: List[:class:`vvspy.obj.Departure`]
+    Returns none on webrequest errors or no results found.
 
     """
-    return get_departures(station_id=station_id, check_time=__datetime.now(), limit=limit,
-                          return_resp=return_resp, **kwargs)
+    return get_departures(
+        station_id=station_id,
+        check_time=__datetime.now(),
+        limit=limit,
+        return_resp=return_resp,
+        session=session,
+        **kwargs
+    )
 
 
-def get_departure(station_id: __Union[str, int], check_time: __datetime = None, debug: bool = False,
-                  request_params: dict = None, return_resp: bool = False, **kwargs)\
-        -> __Union[__Departure, __Response, None]:
+def get_departure(
+    station_id: __Union[str, int],
+    check_time: __datetime = None,
+    debug: bool = False,
+    request_params: dict = None,
+    return_resp: bool = False,
+    session: Session = None,
+    **kwargs
+) -> __Union[__Departure, __Response, None]:
     """
     Same as `get_departures`
     But limited to one obj as result.
@@ -38,11 +56,27 @@ def get_departure(station_id: __Union[str, int], check_time: __datetime = None, 
     """
     try:
         if return_resp:
-            return get_departures(station_id=station_id, check_time=check_time, limit=1, debug=debug,
-                                  request_params=request_params, return_resp=return_resp, **kwargs)
+            return get_departures(
+                station_id=station_id,
+                check_time=check_time,
+                limit=1,
+                debug=debug,
+                request_params=request_params,
+                return_resp=return_resp,
+                session=session,
+                **kwargs
+            )
         else:
-            return get_departures(station_id=station_id, check_time=check_time, limit=1, debug=debug,
-                                  request_params=request_params, return_resp=return_resp, **kwargs)[0]
+            return get_departures(
+                station_id=station_id,
+                check_time=check_time,
+                limit=1,
+                debug=debug,
+                request_params=request_params,
+                return_resp=return_resp,
+                session=session,
+                **kwargs
+            )[0]
     except IndexError:  # no results returned
         if debug:
             print("No departures found.")
@@ -53,24 +87,46 @@ def get_departure(station_id: __Union[str, int], check_time: __datetime = None, 
         return
 
 
-def get_arrival(station_id: __Union[str, int], check_time: __datetime = None, debug: bool = False,
-                request_params: dict = None, return_resp: bool = False, **kwargs)\
-        -> __Union[__Arrival, __Response, None]:
+def get_arrival(
+    station_id: __Union[str, int],
+    check_time: __datetime = None,
+    debug: bool = False,
+    request_params: dict = None,
+    return_resp: bool = False,
+    session: Session = None,
+    **kwargs
+) -> __Union[__Arrival, __Response, None]:
     """
-        Same as `get_arrivals`
-        But limited to one obj as result.
+    Same as `get_arrivals`
+    But limited to one obj as result.
 
-        Returns: :class:`vvspy.obj.Arrival`
-        Returns none on webrequest errors or no results found.
+    Returns: :class:`vvspy.obj.Arrival`
+    Returns none on webrequest errors or no results found.
 
     """
     try:
         if return_resp:
-            return get_arrivals(station_id=station_id, check_time=check_time, limit=1, debug=debug,
-                                request_params=request_params, return_resp=return_resp, **kwargs)
+            return get_arrivals(
+                station_id=station_id,
+                check_time=check_time,
+                limit=1,
+                debug=debug,
+                request_params=request_params,
+                return_resp=return_resp,
+                session=session,
+                **kwargs
+            )
         else:
-            return get_arrivals(station_id=station_id, check_time=check_time, limit=1, debug=debug,
-                                request_params=request_params, return_resp=return_resp, **kwargs)[0]
+            return get_arrivals(
+                station_id=station_id,
+                check_time=check_time,
+                limit=1,
+                debug=debug,
+                request_params=request_params,
+                return_resp=return_resp,
+                session=session,
+                **kwargs
+            )[0]
     except IndexError:  # no results returned
         if debug:
             print("No arrivals found.")
@@ -81,25 +137,48 @@ def get_arrival(station_id: __Union[str, int], check_time: __datetime = None, de
         return
 
 
-def get_trip(origin_station_id: __Union[str, int], destination_station_id: __Union[str, int],
-             check_time: __datetime = None, debug: bool = False, request_params: dict = None,
-             return_resp: bool = False, **kwargs) -> __Union[__Trip, __Response, None]:
+def get_trip(
+    origin_station_id: __Union[str, int],
+    destination_station_id: __Union[str, int],
+    check_time: __datetime = None,
+    debug: bool = False,
+    request_params: dict = None,
+    return_resp: bool = False,
+    session: Session = None,
+    **kwargs
+) -> __Union[__Trip, __Response, None]:
     """
-        Same as `get_trips`
-        But limited to one obj as result.
+    Same as `get_trips`
+    But limited to one obj as result.
 
-        Returns: :class:`vvspy.obj.Trip`
-        Returns none on webrequest errors or no results found.
+    Returns: :class:`vvspy.obj.Trip`
+    Returns none on webrequest errors or no results found.
 
     """
     try:
         if return_resp:
-            return get_trips(origin_station_id=origin_station_id, destination_station_id=destination_station_id,
-                             check_time=check_time, limit=1, debug=debug, request_params=request_params,
-                             return_resp=return_resp, **kwargs)
+            return get_trips(
+                origin_station_id=origin_station_id,
+                destination_station_id=destination_station_id,
+                check_time=check_time,
+                limit=1,
+                debug=debug,
+                request_params=request_params,
+                return_resp=return_resp,
+                session=session,
+                **kwargs
+            )
         else:
-            return get_trips(origin_station_id=origin_station_id, destination_station_id=destination_station_id,
-                             check_time=check_time, limit=1, debug=debug, request_params=request_params, **kwargs)[0]
+            return get_trips(
+                origin_station_id=origin_station_id,
+                destination_station_id=destination_station_id,
+                check_time=check_time,
+                limit=1,
+                debug=debug,
+                request_params=request_params,
+                session=session,
+                **kwargs
+            )[0]
     except IndexError:  # no results returned
         if debug:
             print("No trips found.")


### PR DESCRIPTION
I added optional requests session capability to all requests in vvspy. Users can supply a requests.Session object to method in this library to keep their connections to the VVS servers alive. This eliminates unnecessary re-establishment of existing connections for sequential requests. 

I needed this functionality for a project I am working on with many sequential requests. requests.Session helps with that and it has the same functionality as the regular requests object. This change is minor and more of a convenience change for my project and I wanted to contribute this. Maybe somebody else will find this as useful as I do.

There may be some refactoring of existing code due to my formatter. I hope this won't be an issue.